### PR TITLE
Mention pkgdown site + GitHub + GH issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,8 @@ Imports:
   methods,
   raster,
   sf,
+URL: https://isciences.gitlab.io/exactextractr/, https://github.com/isciences/exactextractr
+BugReports: https://github.com/isciences/exactextractr/issues
 LinkingTo: Rcpp
 Suggests: testthat
 Encoding: UTF-8


### PR DESCRIPTION
Hi @dbaston :wave:,
I've stumbled upon `exactextractr` from your GIS StackExchange [answer](https://gis.stackexchange.com/a/286470). It seems to be a great tool!

I've just realized that the package CRAN page does not mention the GitHub repo nor the pkgdown website. I also added the GitHub repo in the `URL:` field so that `pkgdown` will automatically link to it.

Thank you again for building `exactextractr`!