### PR TITLE
Include cell

### DIFF
--- a/R/exact_extract.R
+++ b/R/exact_extract.R
@@ -280,7 +280,7 @@ emptyVector <- function(rast) {
 
         if (include_cell) {
           if (nrow(vals) == 0) {
-            vals$cell <- integer()
+            vals$cell <- numeric()
           } else {
             rows <- rep(ret$row:(ret$row+nrow(ret$weights) - 1), each=ncol(ret$weights))
             cols <- rep.int(ret$col:(ret$col+ncol(ret$weights) - 1),

--- a/R/exact_extract.R
+++ b/R/exact_extract.R
@@ -84,6 +84,8 @@ if (!isGeneric("exact_extract")) {
 #' @param     include_xy if \code{TRUE}, augment the returned data frame with
 #'                        columns for cell center coordinates (\code{x} and
 #'                        \code{y}) or pass them to \code{fun}
+#' @param     include_cell if \code{TRUE}, augment the returned data frame with
+#'                        column for cell index
 #' @param     fun an optional function or character vector, as described below
 #' @param     max_cells_in_memory the maximum number of raster cells to load at
 #'                                a given time when using a named summary operation
@@ -125,8 +127,8 @@ NULL
 #' @useDynLib exactextractr
 #' @rdname exact_extract
 #' @export
-setMethod('exact_extract', signature(x='Raster', y='sf'), function(x, y, fun=NULL, ..., include_xy=FALSE, progress=TRUE, max_cells_in_memory=30000000) {
-  exact_extract(x, sf::st_geometry(y), fun=fun, ..., include_xy=include_xy, progress=progress, max_cells_in_memory=max_cells_in_memory)
+setMethod('exact_extract', signature(x='Raster', y='sf'), function(x, y, fun=NULL, ..., include_xy=FALSE, progress=TRUE, max_cells_in_memory=30000000, include_cell=FALSE) {
+  exact_extract(x, sf::st_geometry(y), fun=fun, ..., include_xy=include_xy, progress=progress, max_cells_in_memory=max_cells_in_memory, include_cell=include_cell)
 })
 
 # Return the number of standard (non-...) arguments in a supplied function that
@@ -145,7 +147,7 @@ emptyVector <- function(rast) {
          numeric())
 }
 
-.exact_extract <- function(x, y, fun=NULL, ..., weights=NULL, include_xy=FALSE, progress=TRUE, max_cells_in_memory=30000000) {
+.exact_extract <- function(x, y, fun=NULL, ..., weights=NULL, include_xy=FALSE, progress=TRUE, max_cells_in_memory=30000000, include_cell=FALSE) {
   if(!is.null(weights)) {
     if (!startsWith(class(weights), 'Raster')) {
       stop("Weights must be a Raster object.")
@@ -276,6 +278,19 @@ emptyVector <- function(rast) {
           }
         }
 
+        if (include_cell) {
+          if (nrow(vals) == 0) {
+            vals$cell <- integer()
+          } else {
+            rows <- rep(ret$row:(ret$row+nrow(ret$weights) - 1), each=ncol(ret$weights))
+            cols <- rep.int(ret$col:(ret$col+ncol(ret$weights) - 1),
+                                     times = nrow(ret$weights))
+            vals$cell <- raster::cellFromRowCol(x,
+                                           row=rows,
+                                           col=cols)
+
+          }
+        }
         cov_fracs <- as.vector(t(ret$weights))
         vals <- vals[cov_fracs > 0, , drop=FALSE]
         cov_fracs <- cov_fracs[cov_fracs > 0]

--- a/tests/testthat/test_exact_extract.R
+++ b/tests/testthat/test_exact_extract.R
@@ -198,7 +198,14 @@ test_that('We ignore portions of the polygon that extend outside the raster', {
   expect_equal(cells_included,
                data.frame(x=179.75, y=c(0.75, 0.25)),
                check.attributes=FALSE)
-})
+
+
+  index_included <- exact_extract(rast, rect, include_xy=TRUE, include_cell = TRUE)[[1]][, c('x', 'y', 'cell')]
+  expect_equivalent(as.matrix(cells_included[c("x", "y")]),
+               raster::xyFromCell(rast, index_included$cell))
+  expect_equal(index_included$cell,
+               raster::cellFromXY(rast, cbind(cells_included$x, cells_included$y)))
+  })
 
 test_that('Additional arguments can be passed to fun', {
   data <- matrix(1:9, nrow=3, byrow=TRUE)


### PR DESCRIPTION
PR to add `include_cell` argument to provide the `$cell` column, analogously but independent of the `$x` and `$y` columns from `include_cell`. 


I've left 'cell' as numeric which is what raster does, otherwise it overflows for large grids. 

It's *redundant* in the sense that x, y contain the same information (relative to the raster), but this way the user can choose either cell or xy or none, and it's safer in some contexts to have a single-column integer-ish code than to store a cell centre. (I hope you agree!  I use raster's cell abstraction extensively, adding weights is a really nice addition, fasterize provides fast pixel classification but not weights)

Thanks!

