### PR TITLE
Implement parallelised execution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,9 @@ Imports:
 URL: https://isciences.gitlab.io/exactextractr/, https://github.com/isciences/exactextractr
 BugReports: https://github.com/isciences/exactextractr/issues
 LinkingTo: Rcpp
-Suggests: testthat
+Suggests: 
+  testthat,
+  parallel,
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.0.2


### PR DESCRIPTION
Hi,
thank you for your package, very useful to speed-up raster aggregation.
I made some changes in order to further speed-up the extraction exploiting parallel computation. I only made use of base package `parallel` (included as suggested dependency) so not to make dependencies heavier. To use this modality, argument `exact_extract(..., parallel = TRUE)` must be explicitly passed (default is FALSE).
I tested it on Windows (R 4.0.0) and Ubuntu (R 3.6.3).
Hoping you will find this PR useful.

Bye,
Luigi Ranghetti