### PR TITLE
add previous CPP_exact_extract2

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ CPP_coverage_fraction <- function(rast, wkb, crop) {
     .Call('_exactextractr_CPP_coverage_fraction', PACKAGE = 'exactextractr', rast, wkb, crop)
 }
 
+CPP_exact_extract2 <- function(rast, wkb) {
+    .Call('_exactextractr_CPP_exact_extract2', PACKAGE = 'exactextractr', rast, wkb)
+}
+
 CPP_exact_extract <- function(rast, weights, wkb, default_value, default_weight, include_xy, include_cell_number, include_area, area_weights, coverage_areas, p_area_method, include_cols, src_names, p_weights_names, warn_on_disaggregate) {
     .Call('_exactextractr_CPP_exact_extract', PACKAGE = 'exactextractr', rast, weights, wkb, default_value, default_weight, include_xy, include_cell_number, include_area, area_weights, coverage_areas, p_area_method, include_cols, src_names, p_weights_names, warn_on_disaggregate)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -18,6 +18,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// CPP_exact_extract2
+Rcpp::List CPP_exact_extract2(Rcpp::S4& rast, const Rcpp::RawVector& wkb);
+RcppExport SEXP _exactextractr_CPP_exact_extract2(SEXP rastSEXP, SEXP wkbSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type rast(rastSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type wkb(wkbSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPP_exact_extract2(rast, wkb));
+    return rcpp_result_gen;
+END_RCPP
+}
 // CPP_exact_extract
 Rcpp::List CPP_exact_extract(Rcpp::S4& rast, Rcpp::Nullable<Rcpp::S4>& weights, const Rcpp::RawVector& wkb, double default_value, double default_weight, bool include_xy, bool include_cell_number, bool include_area, bool area_weights, bool coverage_areas, Rcpp::Nullable<Rcpp::CharacterVector>& p_area_method, Rcpp::Nullable<Rcpp::List>& include_cols, Rcpp::CharacterVector& src_names, Rcpp::Nullable<Rcpp::CharacterVector>& p_weights_names, bool warn_on_disaggregate);
 RcppExport SEXP _exactextractr_CPP_exact_extract(SEXP rastSEXP, SEXP weightsSEXP, SEXP wkbSEXP, SEXP default_valueSEXP, SEXP default_weightSEXP, SEXP include_xySEXP, SEXP include_cell_numberSEXP, SEXP include_areaSEXP, SEXP area_weightsSEXP, SEXP coverage_areasSEXP, SEXP p_area_methodSEXP, SEXP include_colsSEXP, SEXP src_namesSEXP, SEXP p_weights_namesSEXP, SEXP warn_on_disaggregateSEXP) {
@@ -79,6 +91,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_exactextractr_CPP_coverage_fraction", (DL_FUNC) &_exactextractr_CPP_coverage_fraction, 3},
+    {"_exactextractr_CPP_exact_extract2", (DL_FUNC) &_exactextractr_CPP_exact_extract2, 2},
     {"_exactextractr_CPP_exact_extract", (DL_FUNC) &_exactextractr_CPP_exact_extract, 15},
     {"_exactextractr_CPP_stats", (DL_FUNC) &_exactextractr_CPP_stats, 10},
     {"_exactextractr_CPP_resample", (DL_FUNC) &_exactextractr_CPP_resample, 3},


### PR DESCRIPTION
This `CPP_exact_extract2` is previous script of `CPP_exact_extract` in v0.5.0, which is valuable for multiple files extraction. Hope this function can be kept in the master branch. 
Thank you!

Those script has been tested in win10 and ubuntu 20.04. exactextractr works well on both of them.