### PR TITLE
works with dev versions of raster/terra

### DIFF
--- a/src/coverage_fraction.cpp
+++ b/src/coverage_fraction.cpp
@@ -29,8 +29,9 @@ Rcpp::S4 CPP_coverage_fraction(Rcpp::S4 & rast, const Rcpp::RawVector & wkb, boo
   try {
     GEOSAutoHandle geos;
     Rcpp::Environment raster = Rcpp::Environment::namespace_env("raster");
+    Rcpp::Environment terra = Rcpp::Environment::namespace_env("terra");
     Rcpp::Function rasterFn = raster["raster"];
-    Rcpp::Function crsFn = raster["crs"];
+    Rcpp::Function crsFn = terra["crs"];
 
     auto grid = make_grid(rast);
     auto coverage_fraction = raster_cell_intersection(grid, geos.handle, read_wkb(geos.handle, wkb).get());

--- a/src/resample.cpp
+++ b/src/resample.cpp
@@ -53,8 +53,9 @@ Rcpp::S4 CPP_resample(Rcpp::S4 & rast_in,
                       const Rcpp::StringVector & stat) {
   try {
     Rcpp::Environment raster = Rcpp::Environment::namespace_env("raster");
+    Rcpp::Environment terra = Rcpp::Environment::namespace_env("terra");
     Rcpp::Function rasterFn = raster["raster"];
-    Rcpp::Function valuesFn = raster["values<-"];
+    Rcpp::Function valuesFn = terra["values<-"];
 
     S4RasterSource rsrc(rast_in);
 


### PR DESCRIPTION
The development version of the "raster" package is dependent on "terra" (instead of the other way around). This breaks exactextractr. The two small changes I made appear to fix this.  