### PR TITLE
Fix for bug in .num_expected_args() when `fun` is supplied that has any default argument values of `NA` or `NULL`

### DIFF
--- a/R/exact_extract_helpers.R
+++ b/R/exact_extract_helpers.R
@@ -209,7 +209,7 @@
 .num_expected_args <- function(fun) {
   a <- formals(args(fun))
   a <- a[names(a) != '...']
-  sum(sapply(a, nchar) == 0)
+  sum(sapply(a, nchar) == 0, na.rm = TRUE)
 }
 
 .startReading <- function(r) {

--- a/tests/testthat/test_num_expected_args.R
+++ b/tests/testthat/test_num_expected_args.R
@@ -1,0 +1,56 @@
+context(".num_expected_args")
+
+test_that(
+  desc = 'Number of arguments that a `fun` expects a user to supply matches
+  expectations. That is, the number of non-... arguments that a function expects
+  that don\'t have a default value.',
+  code = {
+
+    # Function has two arguments and no defaults.
+    weighted_mean_no_defaults <- function(df, weighted) {
+      if(!weighted) {
+        out <- mean(df$value)
+      } else {
+        out <- weighted.mean(x = df$value, w = df$value)
+      }
+      out
+    }
+
+    # Function has two arguments, but a non-NULL default is supplied
+    # for one of them.
+    weighted_mean_non_null_defaults <- function(df, weighted = TRUE) {
+      if(!weighted) {
+        out <- mean(df$value)
+      } else {
+        out <- weighted.mean(x = df$value, w = df$value)
+      }
+      out
+    }
+
+    # Function has two arguments, but a NULL default is supplied for
+    # one of them.
+    weighted_mean_null_defaults <- function(df, weighted = NULL) {
+      if(is.null(weighted)) {
+        out <- mean(df$value)
+      } else {
+        out <- weighted.mean(x = df$value, w = df$value)
+      }
+      out
+    }
+
+    # Function has two arguments and no defaults. Should count both
+    # arguments without defaults.
+    expect_equal(.num_expected_args(weighted_mean_no_defaults), 2)
+
+    # Function has two arguments, but a non-NULL default is supplied
+    # for one of them. Should only count the one argument without a
+    # default.
+    expect_equal(.num_expected_args(weighted_mean_non_null_defaults), 1)
+
+    # Function has two arguments, but a NULL default is supplied for
+    # one of them. Should only count the one argument without a default.
+    expect_equal(.num_expected_args(weighted_mean_null_defaults), 1)
+  }
+)
+
+


### PR DESCRIPTION
Addresses https://github.com/isciences/exactextractr/issues/110

exactextractr::exact_extract() errors out when a `fun` is supplied that has any default argument values of `NA` or `NULL`.

We can trace this back to this internal helper function, `.num_expected_args()`, which counts the number of arguments that {exactextractr} expects a user to supply (i.e., not counting arguments that have a default value, as far as I can tell). But the logical operation of `nchar(a) == 0` will produce `NA` instead of a count if any arguments have a default value of `NA` or `NULL`. Including `na.rm = TRUE` appropriately ignores arguments that have a default value (i.e., counts them as `0` in the total) but produces an integer count rather than an `NA`. Including `na.rm = TRUE` also appropriately results in a count of `0` if _all_ arguments have defaults of `NA` or `NULL`.